### PR TITLE
bug: 在alpine linux系统中使用Popen执行rsync命令，会报错

### DIFF
--- a/scowsync.py
+++ b/scowsync.py
@@ -50,7 +50,8 @@ class ScowSync:
             cmd = f'rsync -az --progress -e \'ssh -p {self.port}\' \
                     {src} {self.user}@{self.address}:{os.path.join(self.destinationpath, filepath)} \
                     --partial --inplace'
-        Popen(cmd, stdout=PIPE, universal_newlines=True, shell=True)
+        os.system(cmd)
+        # Popen(cmd, stdout=PIPE, universal_newlines=True, shell=True)
         # with Popen(cmd, stdout=PIPE, universal_newlines=True, shell=True) as popen:
         #     while popen.poll() is None:
         #         line = popen.stdout.readline()
@@ -65,8 +66,8 @@ class ScowSync:
         cmd = f'rsync -az --progress  -e \'ssh -p {self.port}\' \
                 {src} {self.user}@{self.address}:{dst} \
                 --partial --inplace'
-
-        Popen(cmd, stdout=PIPE, universal_newlines=True, shell=True)
+        os.system(cmd)
+        # Popen(cmd, stdout=PIPE, universal_newlines=True, shell=True)
         # with Popen(cmd, stdout=PIPE, universal_newlines=True, shell=True) as popen:
         #     while popen.poll() is None:
         #         line = popen.stdout.readline()


### PR DESCRIPTION
在docker容器中的alpine linux系统中，执行scow-sync，会报以下错误：
**rsync error: errors with program diagnostics (code 13) at log.c(245) [sender=3.2.7]**
通过打印执行的rsync的cmd命令，发现单独用shell执行该cmd命令时没有报错，于是将Popen改为了os.system，报错消失。
但是使用os.system意味着无法使用管道的方式，获取到传输文件的进度。
